### PR TITLE
fix compatible versions

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
     <p>PLV8 is a <em>trusted</em> Javascript language extension for PostgreSQL. It can be
 used for <em>stored procedures</em>, <em>triggers</em>, etc.</p>
 <p>PLV8 works with most versions of Postgres, but works best with <code>13</code> and above,
-including <code>14</code>, <code>16</code>, and <code>16</code>.</p>
+including <code>14</code>, <code>15</code>, and <code>16</code>.</p>
 
       <h2>
         <a name="installing-plv8" class="anchor" href="#installing-plv8">


### PR DESCRIPTION
I assume it was a mistake to say "14, 16, and 16." If 15 is not compatible, that should be called out explicitly.